### PR TITLE
Code refactoring and bugfix

### DIFF
--- a/Excel4Delphi.Common.pas
+++ b/Excel4Delphi.Common.pas
@@ -3,9 +3,9 @@
 interface
 
 uses
-  SysUtils,
-  Types,
-  Classes,
+  System.SysUtils,
+  System.Types,
+  System.Classes,
   Excel4Delphi,
   Excel4Delphi.Xml;
 
@@ -71,7 +71,14 @@ function ZENormalizeAngle180(const value: TZCellTextRotate): integer;
 implementation
 
 uses
-  DateUtils, IOUtils, Winapi.Windows, Variants, VarUtils, NetEncoding;
+{$IFDEF MSWINDOWS}
+  Winapi.Windows,
+{$ENDIF}
+  System.DateUtils,
+  System.IOUtils,
+  System.Variants,
+  System.VarUtils,
+  System.NetEncoding;
 
 function FileCreateTemp(var tempName: string): THandle;
 begin

--- a/Excel4Delphi.ExportHTML.pas
+++ b/Excel4Delphi.ExportHTML.pas
@@ -3,14 +3,20 @@
 interface
 
 uses
-  Windows,
-  SysUtils,
-  UITypes,
-  Types,
-  Classes,
-  Math,
-  Graphics,
-  AnsiStrings,
+{$IFDEF MSWINDOWS}
+  Winapi.Windows,
+{$ENDIF}
+  System.SysUtils,
+  System.UITypes,
+  System.Types,
+  System.Classes,
+  System.Math,
+  System.AnsiStrings,
+{$IFDEF FMX}
+  FMX.Graphics,
+{$ELSE}
+  Vcl.Graphics,
+{$ENDIF}
   Excel4Delphi,
   Excel4Delphi.Xml;
 

--- a/Excel4Delphi.Formula.pas
+++ b/Excel4Delphi.Formula.pas
@@ -3,30 +3,31 @@
 interface
 
 type
-TZEFormula = class
-  /// <summary>
-  /// Return absolute AA styled cell address.
-  /// </summary>
-  class function GetColAddres(const ColumnIndex: integer; FromZero: boolean = true): string; static;
-  /// <summary>
-  /// Extracts column index from it's AA address.
-  /// </summary>
-  class function GetColIndex(ColumnAdress: string; FromZero: boolean = true): integer; static;
-  /// <summary>
-  /// Extracts cell column and row from A1 styled address.
-  /// </summary>
-  class function GetCellCoords(const cell: string; out column, row: integer): boolean; static;
-  /// <summary>
-  /// Extracts range top, left right and bottom from 'А1:B2' based string.
-  /// If string is 'A1' format then right=left, bottom=top.
-  /// </summary>
-  class function GetCellRange(const range: string; out left, top, right, bottom: integer): boolean; static;
-end;
+  TZEFormula = class
+    /// <summary>
+    /// Return absolute AA styled cell address.
+    /// </summary>
+    class function GetColAddres(const ColumnIndex: integer; FromZero: boolean = true): string; static;
+    /// <summary>
+    /// Extracts column index from it's AA address.
+    /// </summary>
+    class function GetColIndex(ColumnAdress: string; FromZero: boolean = true): integer; static;
+    /// <summary>
+    /// Extracts cell column and row from A1 styled address.
+    /// </summary>
+    class function GetCellCoords(const cell: string; out column, row: integer): boolean; static;
+    /// <summary>
+    /// Extracts range top, left right and bottom from 'А1:B2' based string.
+    /// If string is 'A1' format then right=left, bottom=top.
+    /// </summary>
+    class function GetCellRange(const range: string; out left, top, right, bottom: integer): boolean; static;
+  end;
 
 implementation
 
 uses
-  SysUtils, Math;
+  System.SysUtils,
+  System.Math;
 
 const
   CHARS: array [0..25] of char = (

--- a/Excel4Delphi.NumberFormat.pas
+++ b/Excel4Delphi.NumberFormat.pas
@@ -3,7 +3,7 @@
 interface
 
 uses
-  SysUtils,
+  System.SysUtils,
   Excel4Delphi.Xml;
 
 const
@@ -341,7 +341,8 @@ function TryXlsxTimeToDateTime(const XlsxDateTime: string; out retDateTime: TDat
 
 implementation
 
-uses StrUtils,
+uses
+  System.StrUtils,
   Excel4Delphi.Common;
 
 const

--- a/Excel4Delphi.Stream.pas
+++ b/Excel4Delphi.Stream.pas
@@ -3,19 +3,25 @@
 interface
 
 uses
-  SysUtils,
-  Classes,
-  Types,
-  Graphics,
-  UITypes,
-  Windows,
-  Zip,
-  IOUtils,
+{$IFDEF MSWINDOWS}
+  Winapi.Windows,
+{$ENDIF}
+  System.SysUtils,
+  System.Classes,
+  System.Types,
+{$IFDEF FMX}
+  FMX.Graphics,
+{$ELSE}
+  Vcl.Graphics,
+{$ENDIF}
+  System.UITypes,
+  System.Zip,
+  System.IOUtils,
+  System.Generics.Collections,
   Excel4Delphi.Formula,
   Excel4Delphi.Xml,
   Excel4Delphi,
-  Excel4Delphi.Common,
-  Generics.Collections;
+  Excel4Delphi.Common;
 
 type
   TRelationType = (
@@ -269,7 +275,12 @@ function ZEXSLXReadComments(var XMLSS: TZWorkBook; var Stream: TStream): boolean
 
 implementation
 
-uses AnsiStrings, StrUtils, Math, Excel4Delphi.NumberFormat, NetEncoding;
+uses
+  System.AnsiStrings,
+  System.StrUtils,
+  System.Math,
+  System.NetEncoding,
+  Excel4Delphi.NumberFormat;
 
 
 const
@@ -354,12 +365,12 @@ function GetMaximumDigitWidth(fontName: string; fontSize: double): double;
 const
   numbers = '0123456789';
 var
-  bitmap: Graphics.TBitmap;
+  bitmap: TBitmap;
   number: string;
 begin
   //А.А.Валуев Расчитываем ширину самого широкого числа.
   Result := 0;
-  bitmap := Graphics.TBitmap.Create;
+  bitmap := TBitmap.Create;
   try
     bitmap.Canvas.Font.PixelsPerInch := 96;
     bitmap.Canvas.Font.Size := Trunc(fontSize);

--- a/Excel4Delphi.XlsxStream.pas
+++ b/Excel4Delphi.XlsxStream.pas
@@ -8,19 +8,25 @@
 interface
 
 uses
-  SysUtils,
-  Classes,
-  Types,
+{$IFDEF MSWINDOWS}
+  Winapi.Windows,
+{$ENDIF}
+  System.SysUtils,
+  System.Classes,
+  System.Types,
+{$IFDEF FMX}
+  FMX.Graphics,
+{$ELSE}
   Vcl.Graphics,
-  UITypes,
-  Windows,
-  Zip,
-  IOUtils,
+{$ENDIF}
+  System.UITypes,
+  System.Zip,
+  System.IOUtils,
+  System.Generics.Collections,
   Excel4Delphi.Formula,
   Excel4Delphi.Xml,
   Excel4Delphi,
-  Excel4Delphi.Common,
-  Generics.Collections;
+  Excel4Delphi.Common;
 
 type
   TRelationType = (
@@ -204,10 +210,13 @@ type
 
 implementation
 
-uses AnsiStrings, StrUtils, Math, NetEncoding
-  , Excel4Delphi.NumberFormat
-  , Excel4Delphi.Stream
-;
+uses
+  System.AnsiStrings,
+  System.StrUtils,
+  System.Math,
+  System.NetEncoding,
+  Excel4Delphi.NumberFormat,
+  Excel4Delphi.Stream;
 
 const
   SCHEMA_DOC         = 'http://schemas.openxmlformats.org/officeDocument/2006';

--- a/Excel4Delphi.Xml.pas
+++ b/Excel4Delphi.Xml.pas
@@ -3,7 +3,8 @@
 interface
 
 uses
-  SysUtils, Classes;
+  System.SysUtils,
+  System.Classes;
 
 const
   BOMUTF8    = #239#187#191; // EF BB BF
@@ -942,7 +943,8 @@ function RecognizeEncodingXML(var txt: ansistring; out BOM: integer; out cpfromt
 
 implementation
 
-uses Excel4Delphi.Common;
+uses
+  Excel4Delphi.Common;
 
 //// читатели
 

--- a/Excel4Delphi.pas
+++ b/Excel4Delphi.pas
@@ -4665,8 +4665,10 @@ end;
 function TZSheets.Add(title: string): TZSheet;
 begin
   result := TZSheet.Create(FStore);
+  Result.Title := title;
   SetLength(FSheets, Length(FSheets) + 1);
   FSheets[High(FSheets)] := result;
+  FCount := Length(FSheets);
 end;
 
 procedure TZSheets.Assign(Source: TPersistent);

--- a/Excel4Delphi.pas
+++ b/Excel4Delphi.pas
@@ -3,15 +3,21 @@
 interface
 
 uses
-  Classes,
-  SysUtils,
-  StrUtils,
-  Graphics,
-  UITypes,
-  Math,
-  Windows,
-  RegularExpressions,
-  Generics.Collections,
+{$IFDEF MSWINDOWS}
+  Winapi.Windows,
+{$ENDIF}
+  System.Classes,
+  System.SysUtils,
+{$IFDEF FMX}
+  FMX.Graphics,
+{$ELSE}
+  Vcl.Graphics,
+{$ENDIF}
+  System.StrUtils,
+  System.UITypes,
+  System.Math,
+  System.RegularExpressions,
+  System.Generics.Collections,
   System.Contnrs,
   Excel4Delphi.Xml;
 
@@ -2275,7 +2281,9 @@ function IsIdenticalByteArray(Src, Dst: TBytes): boolean;
 
 implementation
 
-uses Excel4Delphi.Formula, Excel4Delphi.Common;
+uses
+  Excel4Delphi.Formula,
+  Excel4Delphi.Common;
 
 var invariantFormatSertting: TFormatSettings;
 


### PR DESCRIPTION
1. Refactored module names in uses sections according to the Embarcadero coding style
2. Separation of module names for FMX and VCL
3. Fixed a bug in the method for adding a new sheet (`function TZSheets.Add(title: string): TZSheet`): the sheet title and number of sheets were not set, which led to memory leaks:
```pascal
destructor TZSheets.Destroy();
var i: integer;
begin
  // FCount was not changed, that is why it will not free added sheets
  for i := 0 to FCount - 1 do
    FreeAndNil(FSheets[i]);
  SetLength(FSheets, 0);
  FSheets := nil;
  FStore := nil;
  inherited Destroy();
end;
```